### PR TITLE
isomorphic-fetch replacing node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lodash.pick": "^3.1.0",
     "minimist": "^1.2.0",
     "nba-client-template": "^3.3.0",
-    "node-fetch": "^1.6.3",
     "pify": "^2.3.0"
   },
   "devDependencies": {

--- a/src/get-json.js
+++ b/src/get-json.js
@@ -19,8 +19,8 @@ function createUrlString (_url, query) {
 }
 
 function createGetJson () {
-  const fetch = require("node-fetch");
-  
+  const fetch = require("isomorphic-fetch");
+
   return function getJson (_url, query, _options = {}) {
     const urlStr = createUrlString(_url, query);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,7 +2447,7 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-fetch@^1.0.1, node-fetch@^1.6.3:
+node-fetch@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
   dependencies:


### PR DESCRIPTION
I have been facing an issue with loading data from the API. Similar to this issue: https://github.com/nickb1080/nba/issues/41

My workaround was to include this library with my front end project. The node-fetch dependency is for the client side and would throw an error when I try to bundle it with webpack. Since isomorphic-fetch was already included in the package.json, I replaced node-fetch and used isomorphic fetch instead.